### PR TITLE
-9 flag support

### DIFF
--- a/killport
+++ b/killport
@@ -24,6 +24,6 @@ $(echo $lsofcmd) | while read -r line; do
     pid=$(echo $line | awk '{print $2}')
 
     echo "Killing $procname with PID: $pid"
-    kill $pid;
+    kill -9 $pid;
   fi
 done


### PR DESCRIPTION
without the flag, the process hangs and you have to run killport another time or more. with the flag one call s just enough.